### PR TITLE
[discussion] Drop font-family quotes from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Transforms v1 styled-components to v2. It
 
 * Adds `px` units where relevant
-* Fixes `font-family` to include quotes
 
 ```bash
 npm install -g jscodeshift
@@ -32,7 +31,7 @@ styled.View`
   top: 10px;
   flex: 1;
   margin: 10px 20px;
-  font-family: "Georgia";
+  font-family: Georgia;
   color: ${props => props.color};
 `;
 ```


### PR DESCRIPTION
Not sure why this has been added. It's not actually necessary for the CSS spec. Not sure if stylis is doing something incorrect because of it, though.